### PR TITLE
Removed Extra URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/*.csv
 data/*.txt
+data/*.csv*

--- a/main.py
+++ b/main.py
@@ -73,32 +73,33 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                 job_data_found = True
                 logger.info(f"Added results number for {key} from {company_name}")
             else:
-                # Check 4: Does the website contain the element of class "job-count"
-                results_element = soup.find(class_="job-count")
-                if results_element != None:
-                    jobs_num_s = results_element.get_text()
-                    # Remove non number chars
-                    jobs_num_s = remove_non_num_chars(jobs_num_s)
-                    jobs_num_l = list(jobs_num_s)
-                    remove = False
-                    for i in range(len(jobs_num_l)):
-                        if jobs_num_l[i] == "(":
-                            remove = True
-                        elif jobs_num_l[i] == ")":
-                            remove = False
-                            jobs_num_l[i] = ""
-                        if remove == True:
-                            jobs_num_l[i] = ""
-                    jobs_num_s = "".join(jobs_num_l)
-                    jobs_num = int(jobs_num_s)
-                    data[key].append(jobs_num)
+                # Check for no search results
+                search_empty_element = soup.find("div", class_="search-empty")
+                no_results_element = soup.find("div", {"ph-page-state": "no-results"})
+                if search_empty_element != None or no_results_element != None:
+                    data[key].append(0)
                     job_data_found = True
                     logger.info(f"Added results number for {key} from {company_name}")
                 else:
-                    # Check for no search results
-                    search_empty_element = soup.find("div", class_="search-empty")
-                    if search_empty_element != None:
-                        data[key].append(0)
+                    # Check 4: Does the website contain the element of class "job-count"
+                    results_element = soup.find(class_="job-count")
+                    if results_element != None:
+                        jobs_num_s = results_element.get_text()
+                        # Remove non number chars
+                        jobs_num_s = remove_non_num_chars(jobs_num_s)
+                        jobs_num_l = list(jobs_num_s)
+                        remove = False
+                        for i in range(len(jobs_num_l)):
+                            if jobs_num_l[i] == "(":
+                                remove = True
+                            elif jobs_num_l[i] == ")":
+                                remove = False
+                                jobs_num_l[i] = ""
+                            if remove == True:
+                                jobs_num_l[i] = ""
+                        jobs_num_s = "".join(jobs_num_l)
+                        jobs_num = int(jobs_num_s)
+                        data[key].append(jobs_num)
                         job_data_found = True
                         logger.info(f"Added results number for {key} from {company_name}")
                     else:
@@ -207,12 +208,12 @@ def main():
         url_info = UrlInfo(url, "CVS Health")
         urls_by_cert[key].append(url_info)
 
-        url = f"https://jobs.walgreens.com/en/search-jobs/{search_query}/1242/1"
-        url_info = UrlInfo(url, "Walgreens")
-        urls_by_cert[key].append(url_info)
-
         url = f"https://careers.mckesson.com/en/search-jobs/{search_query}"
         url_info = UrlInfo(url, "McKesson")
+        urls_by_cert[key].append(url_info)
+
+        url = f"https://jobs.thecignagroup.com/us/en/search-results?keywords={search_query}"
+        url_info = UrlInfo(url, "The Cigna Group")
         urls_by_cert[key].append(url_info)
 
         # URLs of Technology Companies

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ class DataResult:
     job_data_found: bool
 
 def remove_non_num_chars(jobs_num_s: str):
+    """Remove non number characters"""
     jobs_num_s = jobs_num_s.removesuffix("jobs")
     jobs_num_s = jobs_num_s.replace(",", "")
     jobs_num_s = jobs_num_s.replace("+", "")
@@ -29,6 +30,7 @@ def remove_non_num_chars(jobs_num_s: str):
     return jobs_num_s
 
 def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, logger: logging.Logger, company_name: str) -> DataResult:
+    """Scrap HTML content for jobs data"""
     job_data_found = False
     soup = BeautifulSoup(html_content, "lxml")
 
@@ -43,7 +45,6 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
             result_item = result_item.replace("\n", "")
             if result_item == "results":
                 results_s = results_items[i]
-                # Remove non number chars
                 results_s = remove_non_num_chars(results_s)
                 results = int(results_s)
                 data[key].append(results)
@@ -55,7 +56,6 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
         results_element = soup.find(class_="total-jobs")
         if results_element != None:
             results_s = results_element.get_text()
-            # Remove non number chars
             results_s = remove_non_num_chars(results_s)
             results = int(results_s)
             data[key].append(results)
@@ -66,7 +66,6 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
             results_element = soup.find(class_="result-count")
             if results_element != None:
                 results_s = results_element.get_text()
-                # Remove non number chars
                 results_s = remove_non_num_chars(results_s)
                 results = int(results_s)
                 data[key].append(results)
@@ -85,7 +84,6 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                     results_element = soup.find(class_="job-count")
                     if results_element != None:
                         jobs_num_s = results_element.get_text()
-                        # Remove non number chars
                         jobs_num_s = remove_non_num_chars(jobs_num_s)
                         jobs_num_l = list(jobs_num_s)
                         remove = False
@@ -107,7 +105,6 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                         results_element = soup.find("b", {"data-testid": "job-count"})
                         if results_element != None:
                             jobs_num_s = results_element.get_text()
-                            # Remove non number chars
                             jobs_num_s = remove_non_num_chars(jobs_num_s)
                             jobs_num = int(jobs_num_s)
                             data[key].append(jobs_num)
@@ -124,7 +121,6 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                                         jobs_num_element = div_element.find("span", class_="SWhIm")
                                         if jobs_num_element != None:
                                             jobs_num_s = jobs_num_element.get_text()
-                                            # Remove non number chars
                                             jobs_num_s = remove_non_num_chars(jobs_num_s)
                                             jobs_num = int(jobs_num_s)
                                             data[key].append(jobs_num)

--- a/main.py
+++ b/main.py
@@ -21,6 +21,13 @@ class DataResult:
     data: Dict[str, List[str]]
     job_data_found: bool
 
+def remove_non_num_chars(jobs_num_s: str):
+    jobs_num_s = jobs_num_s.removesuffix("jobs")
+    jobs_num_s = jobs_num_s.replace(",", "")
+    jobs_num_s = jobs_num_s.replace("+", "")
+    jobs_num_s = jobs_num_s.strip()
+    return jobs_num_s
+
 def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, logger: logging.Logger, company_name: str) -> DataResult:
     job_data_found = False
     soup = BeautifulSoup(html_content, "lxml")
@@ -36,8 +43,8 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
             result_item = result_item.replace("\n", "")
             if result_item == "results":
                 results_s = results_items[i]
-                results_s = results_s.strip()
-                results_s = results_s.replace(",", "")
+                # Remove non number chars
+                results_s = remove_non_num_chars(results_s)
                 results = int(results_s)
                 data[key].append(results)
                 job_data_found = True
@@ -48,8 +55,8 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
         results_element = soup.find(class_="total-jobs")
         if results_element != None:
             results_s = results_element.get_text()
-            results_s = results_s.strip()
-            results_s = results_s.replace(",", "")
+            # Remove non number chars
+            results_s = remove_non_num_chars(results_s)
             results = int(results_s)
             data[key].append(results)
             job_data_found = True
@@ -59,8 +66,8 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
             results_element = soup.find(class_="result-count")
             if results_element != None:
                 results_s = results_element.get_text()
-                results_s = results_s.strip()
-                results_s = results_s.replace(",", "")
+                # Remove non number chars
+                results_s = remove_non_num_chars(results_s)
                 results = int(results_s)
                 data[key].append(results)
                 job_data_found = True
@@ -70,9 +77,8 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                 results_element = soup.find(class_="job-count")
                 if results_element != None:
                     jobs_num_s = results_element.get_text()
-                    jobs_num_s = jobs_num_s.removesuffix("jobs")
-                    jobs_num_s = jobs_num_s.strip()
-                    jobs_num_s = jobs_num_s.replace(",", "")
+                    # Remove non number chars
+                    jobs_num_s = remove_non_num_chars(jobs_num_s)
                     jobs_num_l = list(jobs_num_s)
                     remove = False
                     for i in range(len(jobs_num_l)):
@@ -100,9 +106,8 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                         results_element = soup.find("b", {"data-testid": "job-count"})
                         if results_element != None:
                             jobs_num_s = results_element.get_text()
-                            jobs_num_s = jobs_num_s.removesuffix("jobs")
-                            jobs_num_s = jobs_num_s.strip()
-                            jobs_num_s = jobs_num_s.replace(",", "")
+                            # Remove non number chars
+                            jobs_num_s = remove_non_num_chars(jobs_num_s)
                             jobs_num = int(jobs_num_s)
                             data[key].append(jobs_num)
                             job_data_found = True
@@ -118,8 +123,8 @@ def scrap_html_content(html_content: str, data: Dict[str, List[str]], key: str, 
                                         jobs_num_element = div_element.find("span", class_="SWhIm")
                                         if jobs_num_element != None:
                                             jobs_num_s = jobs_num_element.get_text()
-                                            jobs_num_s = jobs_num_s.strip()
-                                            jobs_num_s = jobs_num_s.replace(",", "")
+                                            # Remove non number chars
+                                            jobs_num_s = remove_non_num_chars(jobs_num_s)
                                             jobs_num = int(jobs_num_s)
                                             data[key].append(jobs_num)
                                             job_data_found = True
@@ -184,6 +189,7 @@ def main():
     for key in urls_by_cert.keys():
         search_query = quote(key)
 
+        # URLs of Defense Companies
         url = f"https://careers.rtx.com/global/en/search-results?keywords={search_query}"
         url_info = UrlInfo(url, "RTX")
         urls_by_cert[key].append(url_info)
@@ -192,18 +198,21 @@ def main():
         url_info = UrlInfo(url, "Lockheed Martin")
         urls_by_cert[key].append(url_info)
 
-        url = f"https://www.gdit.com/careers/search/?q={search_query}"
-        url_info = UrlInfo(url, "GDIT")
-        urls_by_cert[key].append(url_info)
-
         url = f"https://jobs.baesystems.com/global/en/search-results?keywords={search_query}"
         url_info = UrlInfo(url, "BAE Systems")
         urls_by_cert[key].append(url_info)
 
-        url = f"https://careers.leidos.com/search/jobs?q={search_query}"
-        url_info = UrlInfo(url, "Leidos")
-        urls_by_cert[key].append(url_info)
+        # Remove
+        #url = f"https://www.gdit.com/careers/search/?q={search_query}"
+        #url_info = UrlInfo(url, "GDIT")
+        #urls_by_cert[key].append(url_info)
 
+        # Remove
+        #url = f"https://careers.leidos.com/search/jobs?q={search_query}"
+        #url_info = UrlInfo(url, "Leidos")
+        #urls_by_cert[key].append(url_info)
+
+        # URLs of Healthcare Companies
         url = f"https://jobs.cvshealth.com/us/en/search-results?keywords={search_query}"
         url_info = UrlInfo(url, "CVS Health")
         urls_by_cert[key].append(url_info)
@@ -216,6 +225,7 @@ def main():
         url_info = UrlInfo(url, "McKesson")
         urls_by_cert[key].append(url_info)
 
+        # URLs of Technology Companies
         url = f"https://www.google.com/about/careers/applications/jobs/results?q={search_query}"
         url_info = UrlInfo(url, "Google")
         urls_by_cert[key].append(url_info)

--- a/main.py
+++ b/main.py
@@ -202,16 +202,6 @@ def main():
         url_info = UrlInfo(url, "BAE Systems")
         urls_by_cert[key].append(url_info)
 
-        # Remove
-        #url = f"https://www.gdit.com/careers/search/?q={search_query}"
-        #url_info = UrlInfo(url, "GDIT")
-        #urls_by_cert[key].append(url_info)
-
-        # Remove
-        #url = f"https://careers.leidos.com/search/jobs?q={search_query}"
-        #url_info = UrlInfo(url, "Leidos")
-        #urls_by_cert[key].append(url_info)
-
         # URLs of Healthcare Companies
         url = f"https://jobs.cvshealth.com/us/en/search-results?keywords={search_query}"
         url_info = UrlInfo(url, "CVS Health")


### PR DESCRIPTION
Removed extra URLs of the companies in the defense industry.

Extras
- The web scraper scraps The Cigna Group Careers site instead of Walgreens Careers site.
- Fixed a bug where the plus sign is not removed before converting the jobs number to an integer. 
- Created a function to remove non number characters.