### PR TITLE
Removed Healthcare Career Sites

### DIFF
--- a/config.json5
+++ b/config.json5
@@ -7,17 +7,10 @@
         {"url": "https://jobs.baesystems.com/global/en/search-results?keywords=", "company_name": "BAE Systems"},
         {"url": "https://careers.leidos.com/search/jobs?q=", "company_name": "Leidos"},
     ],
-    "healthcare_career_site_urls": [
-        {"url": "https://jobs.cvshealth.com/us/en/search-results?keywords=", "company_name": "CVS Health"},
-        {"url": "https://careers.mckesson.com/en/search-jobs/", "company_name": "McKesson"},
-        {"url": "https://jobs.thecignagroup.com/us/en/search-results?keywords=", "company_name": "The Cigna Group"},
-        {"url": "https://careers.cencora.com/us/en/search-results?keywords=", "company_name": "Cencora"},
-    ],
     "technology_career_site_urls": [
         {"url": "https://www.google.com/about/careers/applications/jobs/results?q=", "company_name": "Google"},
         {"url": "https://www.amazon.jobs/en/search?base_query=", "company_name": "Amazon"},
         {"url": "https://apply.careers.microsoft.com/careers?query=", "company_name": "Microsoft"},
         {"url": "https://careers.oracle.com/en/sites/jobsearch/jobs?keyword=", "company_name": "Oracle"}
     ]
-
 }

--- a/lib.py
+++ b/lib.py
@@ -32,9 +32,8 @@ def remove_non_num_chars(jobs_num_s: str):
 def solve_cloudflare_turnstitle(title: str):
     """Solve Cloudflare Turnstile"""
     if title == "Just a moment...":
-        time.sleep(10)
         pyautogui.click(544, 433)
-        time.sleep(30)
+        time.sleep(10)
 
 def default_chrome_options(user_agent: str) -> webdriver.ChromeOptions:
     options = webdriver.ChromeOptions()

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def main():
         config = json5.load(f)
 
     certs = config["certs"]
-    career_site_urls = config["defense_career_site_urls"] + config["healthcare_career_site_urls"] + config["technology_career_site_urls"]
+    career_site_urls = config["defense_career_site_urls"] + config["technology_career_site_urls"]
 
     data: Dict[str, List[int]] = {}
     urls_by_cert: Dict[str, List[UrlInfo]] = {}
@@ -62,7 +62,7 @@ def main():
 
             # Note: Selenium is great for getting dynamic HTML content generated from JavaScript
             driver.get(url)
-            time.sleep(2)
+            time.sleep(3)
             title = driver.title
             solve_cloudflare_turnstitle(title)
             html_content = driver.page_source

--- a/popular_it_certs_by_position.py
+++ b/popular_it_certs_by_position.py
@@ -32,9 +32,8 @@ def main():
     certs = config["certs"]
     positions = config["positions"]
     defense_urls_half_length = int(len(config["defense_career_site_urls"])/2)
-    healthcare_urls_half_length = int(len(config["healthcare_career_site_urls"])/2)
     technology_urls_half_length = int(len(config["technology_career_site_urls"])/2)
-    career_site_urls = config["defense_career_site_urls"][0:defense_urls_half_length] + config["healthcare_career_site_urls"][0:healthcare_urls_half_length] + config["technology_career_site_urls"][0:technology_urls_half_length]
+    career_site_urls = config["defense_career_site_urls"][0:defense_urls_half_length] + config["technology_career_site_urls"][0:technology_urls_half_length]
 
     data["Companies"] = []
 
@@ -68,7 +67,7 @@ def main():
 
                 # Note: Selenium is great for getting dynamic HTML content generated from JavaScript
                 driver.get(url)
-                time.sleep(2)
+                time.sleep(3)
                 title = driver.title
                 solve_cloudflare_turnstitle(title)
                 html_content = driver.page_source


### PR DESCRIPTION
Removed the healthcare career site URLs.

## Extras
- Set time.sleep to 3 seconds before getting the title of the website.
- Decreased the usage of time.sleep in the solve_cloudflare_turnstitle function.