### PR TITLE
Added Company Career Sites

### DIFF
--- a/config.json5
+++ b/config.json5
@@ -4,6 +4,8 @@
     "defense_career_site_urls": [
         {"url": "https://careers.rtx.com/global/en/search-results?keywords=", "company_name": "RTX"},
         {"url": "https://www.lockheedmartinjobs.com/search-jobs/", "company_name": "Lockheed Martin"},
+        {"url": "https://www.gdit.com/careers/search/?q=", "company_name": "GDIT"},
+        {"url": "https://jobs.northropgrumman.com/careers?query=", "company_name": "Northrop Grumman"},
         {"url": "https://jobs.baesystems.com/global/en/search-results?keywords=", "company_name": "BAE Systems"},
         {"url": "https://careers.leidos.com/search/jobs?q=", "company_name": "Leidos"},
     ]

--- a/config.json5
+++ b/config.json5
@@ -6,7 +6,6 @@
         {"url": "https://www.lockheedmartinjobs.com/search-jobs/", "company_name": "Lockheed Martin"},
         {"url": "https://www.gdit.com/careers/search/?q=", "company_name": "GDIT"},
         {"url": "https://jobs.northropgrumman.com/careers?query=", "company_name": "Northrop Grumman"},
-        {"url": "https://jobs.baesystems.com/global/en/search-results?keywords=", "company_name": "BAE Systems"},
-        {"url": "https://careers.leidos.com/search/jobs?q=", "company_name": "Leidos"},
+        {"url": "https://jobs.baesystems.com/global/en/search-results?keywords=", "company_name": "BAE Systems"}
     ]
 }

--- a/config.json5
+++ b/config.json5
@@ -1,5 +1,5 @@
 {
-    "certs": ["Comptia Network+", "Comptia Security+", "CCNA"],
+    "certs": ["Comptia Network+", "CCNA", "Comptia Security+"],
     "positions": ["Network Engineer", "Network Administrator", "Cybersecurity Engineer"],
     "defense_career_site_urls": [
         {"url": "https://careers.rtx.com/global/en/search-results?keywords=", "company_name": "RTX"},


### PR DESCRIPTION
Added company career site URLs.

## Extras
- Removed the Leidos career site URL.
- Moved CCNA behind CompTIA Network+.